### PR TITLE
Add Support for Excluding Specific Achievement IDs from Account-Wide Sync

### DIFF
--- a/conf/mod_achievements.conf.dist
+++ b/conf/mod_achievements.conf.dist
@@ -14,4 +14,4 @@ Account.Achievements.Announce = 1
 
 # List of achievement IDs to exclude (comma-separated)
 
-Account.Achievements.Excluded = 5090,5091
+Account.Achievements.Excluded = 0

--- a/conf/mod_achievements.conf.dist
+++ b/conf/mod_achievements.conf.dist
@@ -11,3 +11,7 @@ Account.Achievements.Enable = 1
 # Announce the module when the player logs in?
 
 Account.Achievements.Announce = 1
+
+# List of achievement IDs to exclude (comma-separated)
+
+Account.Achievements.Excluded = 5090,5091

--- a/src/mod_achievements.cpp
+++ b/src/mod_achievements.cpp
@@ -19,7 +19,7 @@
 
 class AccountAchievements : public PlayerScript
 {
-	static const bool limitrace = false; // This set to true will only achievements from chars on the same team, do what you want. NOT RECOMMANDED TO BE CHANGED!!!
+	static const bool limitrace = true; // This set to true will only achievements from chars on the same team, do what you want. NOT RECOMMANDED TO BE CHANGED!!!
 	static const bool limitlevel = false; // This checks the player's level and will only add achievements to players of that level.
 	int minlevel = 80; // It's set to players of the level 60. Requires limitlevel to be set to true.
 	int setlevel = 1; // Dont Change

--- a/src/mod_achievements.cpp
+++ b/src/mod_achievements.cpp
@@ -1,3 +1,15 @@
+/*
+<--------------------------------------------------------------------------->
+- Developer(s): Lille Carl, Grim/Render
+- Complete: %100
+- ScriptName: 'AccountAchievements'
+- Comment: Tested and Works.
+- Orginial Creator: Lille Carl
+- Edited: Render/Grim
+- Edited: Blkht01(Qeme) Classic Plus - Added Exclusion
+<--------------------------------------------------------------------------->
+*/
+
 #include "Config.h"
 #include "ScriptMgr.h"
 #include "Chat.h"

--- a/src/mod_achievements.cpp
+++ b/src/mod_achievements.cpp
@@ -1,37 +1,46 @@
-/*
-<--------------------------------------------------------------------------->
-- Developer(s): Lille Carl, Grim/Render
-- Complete: %100
-- ScriptName: 'AccountAchievements'
-- Comment: Tested and Works.
-- Orginial Creator: Lille Carl
-- Edited: Render/Grim
-<--------------------------------------------------------------------------->
-*/
-
 #include "Config.h"
 #include "ScriptMgr.h"
 #include "Chat.h"
 #include "Player.h"
+#include <unordered_set>
+#include <sstream>
 
 class AccountAchievements : public PlayerScript
 {
-	static const bool limitrace = true; // This set to true will only achievements from chars on the same team, do what you want. NOT RECOMMANDED TO BE CHANGED!!!
-	static const bool limitlevel = false; // This checks the player's level and will only add achievements to players of that level.
-	int minlevel = 80; // It's set to players of the level 60. Requires limitlevel to be set to true.
-	int setlevel = 1; // Dont Change
+	static const bool limitrace = false;
+	static const bool limitlevel = false;
+	int minlevel = 80;
+	int setlevel = 1;
+
+	std::unordered_set<uint32> excludedAchievements; // Store excluded achievement IDs
 
 public:
-	AccountAchievements() : PlayerScript("AccountAchievements") { }
+	AccountAchievements() : PlayerScript("AccountAchievements") 
+	{
+		// Load excluded achievements from config
+		std::string excludeList = sConfigMgr->GetOption<std::string>("Account.Achievements.Excluded", "");
+		std::stringstream ss(excludeList);
+		std::string token;
 
-	void OnLogin(Player* pPlayer)
+		while (std::getline(ss, token, ',')) 
+		{
+			try {
+				uint32 id = std::stoul(token);
+				excludedAchievements.insert(id);
+			} catch (...) {
+				LOG_ERROR("module", "Invalid achievement ID in Account.Achievements.Excluded: {}", token);
+			}
+		}
+	}
+
+	void OnLogin(Player* pPlayer) override
 	{
 		if (sConfigMgr->GetOption<bool>("Account.Achievements.Enable", true))
-        {
+		{
 			if (sConfigMgr->GetOption<bool>("Account.Achievements.Announce", true))
-            {
-                ChatHandler(pPlayer->GetSession()).SendSysMessage("This server is running the |cff4CFF00AccountAchievements |rmodule.");
-            }
+			{
+				ChatHandler(pPlayer->GetSession()).SendSysMessage("This server is running the |cff4CFF00AccountAchievements |rmodule.");
+			}
 
 			std::vector<uint32> Guids;
 			QueryResult result1 = CharacterDatabase.Query("SELECT guid, race FROM characters WHERE account = {}", pPlayer->GetSession()->GetAccountId());
@@ -41,11 +50,10 @@ public:
 			do
 			{
 				Field* fields = result1->Fetch();
-
 				uint32 race = fields[1].Get<uint8>();
 
 				if ((Player::TeamIdForRace(race) == Player::TeamIdForRace(pPlayer->getRace())) || !limitrace)
-					Guids.push_back(result1->Fetch()[0].Get<uint32>());
+					Guids.push_back(fields[0].Get<uint32>());
 
 			} while (result1->NextRow());
 
@@ -59,14 +67,23 @@ public:
 
 				do
 				{
-					Achievement.push_back(result2->Fetch()[0].Get<uint32>());
+					uint32 achievementID = result2->Fetch()[0].Get<uint32>();
+					// Only add if not in the exclusion list
+					if (excludedAchievements.find(achievementID) == excludedAchievements.end()) 
+					{
+						Achievement.push_back(achievementID);
+					}
+
 				} while (result2->NextRow());
 			}
 
 			for (auto& i : Achievement)
 			{
 				auto sAchievement = sAchievementStore.LookupEntry(i);
+				if (sAchievement)
+				{
 					AddAchievements(pPlayer, sAchievement->ID);
+				}
 			}
 		}
 	}
@@ -74,12 +91,18 @@ public:
 	void AddAchievements(Player* player, uint32 AchievementID)
 	{
 		if (sConfigMgr->GetOption<bool>("Account.Achievements.Enable", true))
-        {
+		{
 			if (limitlevel)
 				setlevel = minlevel;
 
-			if (player->getLevel() >= setlevel)
-				player->CompletedAchievement(sAchievementStore.LookupEntry(AchievementID));
+			if (player->GetLevel() >= setlevel)
+			{
+				// Check exclusion before granting achievement
+				if (excludedAchievements.find(AchievementID) == excludedAchievements.end()) 
+				{
+					player->CompletedAchievement(sAchievementStore.LookupEntry(AchievementID));
+				}
+			}
 		}
 	}
 };

--- a/src/mod_achievements.cpp
+++ b/src/mod_achievements.cpp
@@ -19,10 +19,10 @@
 
 class AccountAchievements : public PlayerScript
 {
-	static const bool limitrace = false;
-	static const bool limitlevel = false;
-	int minlevel = 80;
-	int setlevel = 1;
+	static const bool limitrace = false; // This set to true will only achievements from chars on the same team, do what you want. NOT RECOMMANDED TO BE CHANGED!!!
+	static const bool limitlevel = false; // This checks the player's level and will only add achievements to players of that level.
+	int minlevel = 80; // It's set to players of the level 60. Requires limitlevel to be set to true.
+	int setlevel = 1; // Dont Change
 
 	std::unordered_set<uint32> excludedAchievements; // Store excluded achievement IDs
 


### PR DESCRIPTION
This PR introduces a new feature that allows server administrators to manually exclude specific achievement IDs from being shared account-wide. A new configuration option (Account.Achievements.Excluded) has been added to worldserver.conf, allowing a comma-separated list of achievement IDs to be specified.

### Changes & Enhancements

✅ New Config Option

-     Account.Achievements.Excluded = 1234,5678,91011
- Admins can now define which achievements should remain character-specific.

✅ Code Adjustments

- Introduced an unordered_set<uint32> to store excluded achievements for fast lookups.
- Achievements are now checked against this exclusion list before being granted.
- Improved logging to warn if an invalid achievement ID is present in the config.

✅ Performance Optimizations

- Instead of looping through exclusions in an array, we use a hash set lookup for O(1) efficiency.
- Prevents unnecessary database writes for excluded achievements.

### How to Test

- Update worldserver.conf and add some excluded achievements:
- Account.Achievements.Excluded = 1234,5678,91011
- Restart the server.
- Log in with a character that has these achievements.
- Expected Behavior: The excluded achievements should not be granted across other characters in the same account.

✅ Closes https://github.com/azerothcore/mod-account-achievements/issues/3