### PR TITLE
fixed compile error

### DIFF
--- a/src/mod_achievements.cpp
+++ b/src/mod_achievements.cpp
@@ -45,7 +45,7 @@ public:
 		}
 	}
 
-	void OnLogin(Player* pPlayer) override
+	void OnLogin(Player* pPlayer)
 	{
 		if (sConfigMgr->GetOption<bool>("Account.Achievements.Enable", true))
 		{


### PR DESCRIPTION
I´m not c++ dev, but his fixes following compile error for me. This override was added in last commit by @blkht01

/srv/azerothcore-wotlk/modules/mod-account-achievements/src/mod_achievements.cpp:48:32: fatal error: only virtual member functions can be marked 'override'
   48 |         void OnLogin(Player* pPlayer) override
      |                                       ^~~~~~~~
1 error generated.